### PR TITLE
Add chezmoi scripts and minimize Dockerfile for dotfiles Phase 2

### DIFF
--- a/.github/workflows/dotfiles.yml
+++ b/.github/workflows/dotfiles.yml
@@ -67,33 +67,13 @@ jobs:
         if: matrix.mode == 'container'
         run: |
           docker run --rm \
-            -v ${{ github.workspace }}/dotfiles:/home/testuser/dotfiles-src:ro \
+            -v ${{ github.workspace }}/dotfiles:/home/testuser/dotfiles \
+            -e CI=true \
             dotfiles-test bash -c "
-              cp -a /home/testuser/dotfiles-src /home/testuser/dotfiles &&
-              chezmoi init --source=/home/testuser/dotfiles --no-tty &&
-              chezmoi apply --source=/home/testuser/dotfiles --no-tty &&
-              echo 'chezmoi apply succeeded'
-            "
-      - name: Verify deployed files in container
-        if: matrix.mode == 'container'
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}/dotfiles:/home/testuser/dotfiles-src:ro \
-            dotfiles-test bash -c "
-              cp -a /home/testuser/dotfiles-src /home/testuser/dotfiles &&
               chezmoi init --source=/home/testuser/dotfiles --no-tty &&
               chezmoi apply --source=/home/testuser/dotfiles --no-tty &&
               test -f ~/.config/fish/config.fish &&
-              echo 'All expected files present'
-            "
-      - name: Run tomei validate in container
-        if: matrix.mode == 'container'
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}/dotfiles:/home/testuser/dotfiles-src:ro \
-            dotfiles-test bash -c "
-              cp -a /home/testuser/dotfiles-src /home/testuser/dotfiles &&
-              tomei validate /home/testuser/dotfiles/dot_config/tomei/
+              echo 'All checks passed'
             "
 
       # --- native mode ---

--- a/dotfiles/.chezmoiscripts/run_once_after_90-set-fish-default-shell.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_once_after_90-set-fish-default-shell.sh.tmpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+FISH_PATH="$(command -v fish 2>/dev/null || true)"
+
+if [ -z "$FISH_PATH" ]; then
+    echo "WARN: fish not found, skipping"
+    exit 0
+fi
+
+# Check current default shell
+{{ if .is_linux -}}
+CURRENT_SHELL="$(getent passwd "$(whoami)" | cut -d: -f7)"
+{{ else if .is_darwin -}}
+CURRENT_SHELL="$(dscl . -read /Users/"$(whoami)" UserShell 2>/dev/null | awk '{print $2}' || echo "")"
+{{ end -}}
+
+if [ "$CURRENT_SHELL" = "$FISH_PATH" ]; then
+    echo "fish is already the default shell"
+    exit 0
+fi
+
+echo "Setting fish ($FISH_PATH) as default shell..."
+
+if ! grep -qF "$FISH_PATH" /etc/shells; then
+    echo "$FISH_PATH" | sudo tee -a /etc/shells
+fi
+
+{{ if .is_linux -}}
+sudo chsh -s "$FISH_PATH" "$(whoami)"
+{{ else if .is_darwin -}}
+chsh -s "$FISH_PATH"
+{{ end -}}
+
+echo "Default shell changed to fish"

--- a/dotfiles/.chezmoiscripts/run_once_after_91-gnome-dconf.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_once_after_91-gnome-dconf.sh.tmpl
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+{{ if and .is_linux (not .headless) -}}
+if ! command -v dconf &>/dev/null; then
+    echo "dconf not found, skipping GNOME settings"
+    exit 0
+fi
+
+DCONF_FILE="${HOME}/.config/dconf/gnome.ini"
+
+if [ ! -f "$DCONF_FILE" ]; then
+    echo "WARN: $DCONF_FILE not found, skipping"
+    exit 0
+fi
+
+echo "Applying GNOME dconf settings from $DCONF_FILE ..."
+dconf load / < "$DCONF_FILE"
+echo "GNOME dconf settings applied"
+
+{{ else -}}
+echo "Skipping GNOME dconf settings (headless={{ .headless }}, os={{ .os }})"
+{{ end -}}

--- a/dotfiles/.chezmoiscripts/run_once_before_00-bootstrap-dirs.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_once_before_00-bootstrap-dirs.sh.tmpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+dirs=(
+    "${HOME}/workspace/github.com"
+    "${HOME}/.local/bin"
+    "${HOME}/.config"
+    "${HOME}/.cache"
+)
+
+for d in "${dirs[@]}"; do
+    if [ ! -d "$d" ]; then
+        mkdir -p "$d"
+        echo "Created: $d"
+    fi
+done

--- a/dotfiles/.chezmoiscripts/run_once_before_02-install-tomei.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_once_before_02-install-tomei.sh.tmpl
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+if command -v tomei &>/dev/null; then
+    echo "tomei already installed: $(tomei version 2>/dev/null || echo 'unknown')"
+    exit 0
+fi
+
+echo "Installing tomei to ~/.local/bin/ ..."
+curl -fsSL https://raw.githubusercontent.com/terassyi/tomei/main/install.sh | sh
+
+if command -v tomei &>/dev/null; then
+    echo "tomei installed: $(tomei version 2>/dev/null || echo 'done')"
+else
+    echo "ERROR: tomei installation failed"
+    exit 1
+fi

--- a/dotfiles/.chezmoiscripts/run_onchange_after_01-apply-tomei.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_onchange_after_01-apply-tomei.sh.tmpl
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# tomei manifest hashes (triggers re-run on change):
+# {{ include "dot_config/tomei/common-tools.cue" | sha256sum }}
+# {{ include "dot_config/tomei/tomei_platform.cue" | sha256sum }}
+
+TOMEI_DIR="${HOME}/.config/tomei"
+
+if ! command -v tomei &>/dev/null; then
+    echo "WARN: tomei not found, skipping"
+    exit 0
+fi
+
+if [ ! -d "$TOMEI_DIR" ]; then
+    echo "WARN: $TOMEI_DIR not found, skipping"
+    exit 0
+fi
+
+tomei init --yes
+tomei validate "$TOMEI_DIR"
+
+if [ "${CI:-}" = "true" ]; then
+    echo "CI: skipping tomei apply"
+else
+    tomei apply "$TOMEI_DIR"
+    echo "tomei apply completed"
+fi

--- a/dotfiles/.chezmoiscripts/run_onchange_before_01-install-packages.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_onchange_before_01-install-packages.sh.tmpl
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# {{ include "dot_config/packages/ubuntu.txt" | sha256sum }}
+
+{{ if .is_linux -}}
+readarray -t PACKAGES <<'PKG_LIST'
+{{ include "dot_config/packages/ubuntu.txt" -}}
+PKG_LIST
+
+MISSING=()
+for pkg in "${PACKAGES[@]}"; do
+    [ -z "$pkg" ] && continue
+    if ! dpkg -s "$pkg" &>/dev/null; then
+        MISSING+=("$pkg")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "Installing missing packages: ${MISSING[*]}"
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends "${MISSING[@]}"
+else
+    echo "All required packages already installed"
+fi
+
+if ! locale -a 2>/dev/null | grep -q "en_US.utf8"; then
+    sudo locale-gen en_US.UTF-8
+fi
+
+{{ else if .is_darwin -}}
+if ! command -v fish &>/dev/null; then
+    echo "Installing fish shell via official .pkg installer..."
+    FISH_VERSION="$(curl -fsSL https://api.github.com/repos/fish-shell/fish-shell/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
+    FISH_PKG_URL="https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.pkg"
+    TMPDIR="$(mktemp -d)"
+    curl -fsSL -o "${TMPDIR}/fish.pkg" "$FISH_PKG_URL"
+    sudo installer -pkg "${TMPDIR}/fish.pkg" -target /
+    rm -rf "$TMPDIR"
+    echo "fish ${FISH_VERSION} installed"
+else
+    echo "fish already installed: $(fish --version)"
+fi
+
+{{ end -}}

--- a/dotfiles/Dockerfile
+++ b/dotfiles/Dockerfile
@@ -1,22 +1,17 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git file fish sudo locales \
-    && rm -rf /var/lib/apt/lists/* \
-    && locale-gen en_US.UTF-8
+    ca-certificates curl sudo \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /usr/bin/fish testuser \
+RUN useradd -m -s /bin/bash testuser \
     && echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # chezmoi
 RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
 
 USER testuser
-
-# tomei
-RUN curl -fsSL https://raw.githubusercontent.com/terassyi/tomei/main/install.sh | sh
 WORKDIR /home/testuser
-ENV LANG=en_US.UTF-8
 ENV PATH="/home/testuser/.local/bin:${PATH}"
 
-CMD ["fish"]
+CMD ["bash"]

--- a/dotfiles/Makefile
+++ b/dotfiles/Makefile
@@ -8,22 +8,22 @@ build:
 
 run:
 	docker run --rm -it \
-		-v $(DOTFILES_DIR):/home/testuser/dotfiles:ro \
+		-v $(DOTFILES_DIR):/home/testuser/dotfiles \
 		$(IMAGE) fish
 
 test:
 	docker run --rm \
-		-v $(DOTFILES_DIR):/home/testuser/dotfiles-src:ro \
+		-v $(DOTFILES_DIR):/home/testuser/dotfiles \
+		-e CI=true \
 		$(IMAGE) bash -c " \
-		cp -a /home/testuser/dotfiles-src /home/testuser/dotfiles && \
 		chezmoi init --source=/home/testuser/dotfiles --no-tty && \
-		chezmoi diff --source=/home/testuser/dotfiles --no-tty || true && \
-		tomei validate /home/testuser/dotfiles/dot_config/tomei/ && \
+		chezmoi apply --source=/home/testuser/dotfiles --no-tty && \
+		test -f ~/.config/fish/config.fish && \
 		echo 'All checks passed'"
 
 shell:
 	docker run --rm -it \
-		-v $(DOTFILES_DIR):/home/testuser/dotfiles:ro \
+		-v $(DOTFILES_DIR):/home/testuser/dotfiles \
 		$(IMAGE) bash
 
 clean:

--- a/dotfiles/dot_config/dconf/gnome.ini.tmpl
+++ b/dotfiles/dot_config/dconf/gnome.ini.tmpl
@@ -1,0 +1,72 @@
+[org/gnome/shell]
+disable-user-extensions=false
+enabled-extensions=['dash-to-dock@micxgx.gmail.com', 'gTile@vibou', 'user-theme@gnome-shell-extensions.gcampax.github.com', 'blur-my-shell@aunetx', 'pip-on-top@rafostar.github.com', 'space-bar@luchrioh', 'system-monitor@gnome-shell-extensions.gcampax.github.com']
+favorite-apps=['google-chrome.desktop', 'com.mitchellh.ghostty.desktop', 'code.desktop', 'discord.desktop', 'slack.desktop']
+
+[org/gnome/desktop/interface]
+overlay-scrolling=false
+color-scheme='prefer-dark'
+accent-color='teal'
+
+[org/gnome/desktop/background]
+color-shading-type='solid'
+picture-uri='file:///home/{{ .username }}/.local/share/backgrounds/interstellar.jpg'
+picture-uri-dark='file:///home/{{ .username }}/.local/share/backgrounds/interstellar.jpg'
+primary-color='#000000000000'
+secondary-color='#000000000000'
+
+[org/gnome/desktop/input-sources]
+current=uint32 0
+sources=[('xkb', 'us'), ('ibus', 'mozc-on')]
+
+[org/gnome/desktop/session]
+idle-delay=uint32 600
+
+[org/gnome/mutter]
+edge-tiling=true
+
+[org/gnome/shell/extensions/blur-my-shell]
+settings-version=2
+
+[org/gnome/shell/extensions/blur-my-shell/dash-to-dock]
+pipeline='pipeline_default_rounded'
+
+[org/gnome/shell/extensions/blur-my-shell/lockscreen]
+pipeline='pipeline_default'
+
+[org/gnome/shell/extensions/blur-my-shell/overview]
+pipeline='pipeline_default'
+
+[org/gnome/shell/extensions/blur-my-shell/panel]
+pipeline='pipeline_default'
+
+[org/gnome/shell/extensions/blur-my-shell/screenshot]
+pipeline='pipeline_default'
+
+[org/gnome/shell/extensions/space-bar/appearance]
+inactive-workspace-text-color='rgb(154,153,150)'
+workspace-margin=3
+workspace-bar-padding=3
+
+[org/gnome/shell/extensions/space-bar/behavior]
+scroll-wheel='panel'
+show-empty-workspaces=false
+smart-workspace-names=false
+toggle-overview=false
+
+[org/gnome/shell/extensions/dash-to-dock]
+dock-position='BOTTOM'
+extend-height=false
+animate-show-apps=false
+apply-custom-theme=false
+background-opacity=0.80000000000000004
+dash-max-icon-size=32
+hot-keys=false
+intellihide-mode='FOCUS_APPLICATION_WINDOWS'
+show-trash=false
+transparency-mode='DYNAMIC'
+
+[org/gnome/shell/extensions/gtile]
+grid-rows=3
+grid-cols=3
+show-icon-in-panel=true

--- a/dotfiles/dot_config/packages/ubuntu.txt
+++ b/dotfiles/dot_config/packages/ubuntu.txt
@@ -1,0 +1,7 @@
+ca-certificates
+curl
+file
+fish
+git
+locales
+sudo


### PR DESCRIPTION
chezmoi apply now bootstraps the full environment from a minimal
container (curl/ca-certificates/sudo/chezmoi only). Six run scripts
handle package installation, tomei setup, fish default shell, and
GNOME dconf settings. Test target uses chezmoi apply with CI=true.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
