### PR TITLE
Run test.sh in native CI mode

### DIFF
--- a/.github/workflows/dotfiles.yml
+++ b/.github/workflows/dotfiles.yml
@@ -75,16 +75,6 @@ jobs:
       - name: Install chezmoi (native)
         if: matrix.mode == 'native'
         run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
-      - name: Install tomei (native)
+      - name: Run test (native)
         if: matrix.mode == 'native'
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/terassyi/tomei/main/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: chezmoi diff (native, dry-run)
-        if: matrix.mode == 'native'
-        run: |
-          chezmoi init --source=${{ github.workspace }}/dotfiles --no-tty
-          chezmoi diff --source=${{ github.workspace }}/dotfiles --no-tty || true
-      - name: tomei validate (native)
-        if: matrix.mode == 'native'
-        run: tomei validate ${{ github.workspace }}/dotfiles/dot_config/tomei/
+        run: bash dotfiles/test.sh "${{ github.workspace }}/dotfiles"

--- a/.github/workflows/dotfiles.yml
+++ b/.github/workflows/dotfiles.yml
@@ -78,3 +78,5 @@ jobs:
       - name: Run test (native)
         if: matrix.mode == 'native'
         run: bash dotfiles/test.sh "${{ github.workspace }}/dotfiles"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dotfiles/.chezmoiscripts/run_once_after_90-set-fish-default-shell.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_once_after_90-set-fish-default-shell.sh.tmpl
@@ -29,7 +29,7 @@ fi
 {{ if .is_linux -}}
 sudo chsh -s "$FISH_PATH" "$(whoami)"
 {{ else if .is_darwin -}}
-chsh -s "$FISH_PATH"
+sudo chsh -s "$FISH_PATH" "$(whoami)"
 {{ end -}}
 
 echo "Default shell changed to fish"

--- a/dotfiles/.chezmoiscripts/run_onchange_before_01-install-packages.sh.tmpl
+++ b/dotfiles/.chezmoiscripts/run_onchange_before_01-install-packages.sh.tmpl
@@ -31,7 +31,11 @@ fi
 {{ else if .is_darwin -}}
 if ! command -v fish &>/dev/null; then
     echo "Installing fish shell via official .pkg installer..."
-    FISH_VERSION="$(curl -fsSL https://api.github.com/repos/fish-shell/fish-shell/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
+    CURL_OPTS=(-fsSL)
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        CURL_OPTS+=(-H "Authorization: token ${GITHUB_TOKEN}")
+    fi
+    FISH_VERSION="$(curl "${CURL_OPTS[@]}" https://api.github.com/repos/fish-shell/fish-shell/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
     FISH_PKG_URL="https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.pkg"
     TMPDIR="$(mktemp -d)"
     curl -fsSL -o "${TMPDIR}/fish.pkg" "$FISH_PKG_URL"

--- a/dotfiles/test.sh
+++ b/dotfiles/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-DOTFILES_SOURCE="/home/testuser/dotfiles"
+DOTFILES_SOURCE="${1:-/home/testuser/dotfiles}"
 
 echo "==> chezmoi init"
 chezmoi init --source="$DOTFILES_SOURCE" --no-tty


### PR DESCRIPTION
- Replace dry-run (chezmoi diff + tomei validate) with full test.sh
  execution in native mode, matching container mode behavior
- Accept dotfiles source path as argument in test.sh
- Use sudo chsh on macOS to avoid interactive password prompt

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
